### PR TITLE
[ci skip] Add update-grayskull and automerge=true

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,4 +6,5 @@ conda_build:
   pkg_format: '2'
 bot:
   automerge: true
+  inspection: update-grayskull
 conda_build_tool: rattler-build


### PR DESCRIPTION
This PR enables Grayskull to automatically update the run requirements of your feedstock when a new package version is found.

This feature has been available for v1 (rattler-build) recipes since [regro/cf-scripts#4575](https://github.com/regro/cf-scripts/pull/4575).

It configures `conda-forge.yml` as follows:
```yaml
bot:
  automerge: true
  inspection: update-grayskull
```